### PR TITLE
refactor: remake make scrapping function into src > scsrappings > ind…

### DIFF
--- a/src/scrappings/index.js
+++ b/src/scrappings/index.js
@@ -5,9 +5,19 @@ const fetchJobs = require("./jerimumjobs");
 async function makeScrapping() {
   console.log("Iniciando scrapping...");
 
-  await fetchEditais().then((editais) => (global.appContext.editais = editais));
-  await fetchMenuRU().then((menu) => (global.appContext.ruCardapio = menu));
-  await fetchJobs().then((jobs) => (global.appContext.jobs = jobs));
+  const scrapingPromises = [fetchEditais(), fetchMenuRU(), fetchJobs()];
+
+  // Leia mais sobre allSettled 
+  const results = await Promise.allSettled(scrapingPromises);
+
+  // Diferentemente do Promise.all, o allSettled armazena os resultados. Se necessário, crie uma função extra para validar.
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      global.appContext[index === 0 ? "editais" : index === 1 ? "ruCardapio" : "jobs"] = result.value;
+    } else {
+      console.error(`Error fetching data for ${index === 0 ? "editais" : index === 1 ? "menuRU" : "jobs"}:`, result.reason);
+    }
+  });
 
   console.log("Scrapping finalizado!");
 }

--- a/src/scrappings/index.js
+++ b/src/scrappings/index.js
@@ -7,10 +7,8 @@ async function makeScrapping() {
 
   const scrapingPromises = [fetchEditais(), fetchMenuRU(), fetchJobs()];
 
-  // Leia mais sobre allSettled 
   const results = await Promise.allSettled(scrapingPromises);
 
-  // Diferentemente do Promise.all, o allSettled armazena os resultados. Se necessário, crie uma função extra para validar.
   results.forEach((result, index) => {
     if (result.status === "fulfilled") {
       global.appContext[index === 0 ? "editais" : index === 1 ? "ruCardapio" : "jobs"] = result.value;


### PR DESCRIPTION
- Use all settled instead `await`.

**Teste esse código antes de aceitar o pr**

### Seu problema:
- Perceba que na abordagem que você utiliza o código irá quebrar se alguma das requisições feitas através do `axios` não funcionar. O comando `await` faz com que a execução do seu código fique travado até que a promise seja resolvida. Isso significa que se alguma falhar, for rejeitada, ou não funcionar como você espera, as outras requisições não serão chamadas. Além disso, o `then` só irá lidar com os callbacks que funcionaram corretamente.
 - Note que um dos serviços que você está fazendo scrapping pode ficar fora do ar, certo ? E se um deles falhar, você não quer que suas requisições quebrem, ou que seu scrapper não funcione corretamente.

### Minha sugestão:
- Recomendo utilizar `Promises` para suas requisições. Isso irá lidar com as requests caso elas sejam bem-sucedidas, ou não. Isso tornará sua aplicação mais robusta e tolerável a erros. 
- De maneira curta e direta: O `Promise.allSettled ` recebe um objeto de `Promises` e irá iterar sobre todas elas, até que sejam concluídas. Ao concluir, ele retornará um objeto com o resultado de cada requisição.
- Isso fará com que seu código seja capaz de lidar com erros e comportamentos inesperado das suas requisições.
- Além disso, uma boa prática para ser adicionado ao seu background de experiência


### Referências:

[Promise.allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
[Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)


### Recomendações adicionais:

- Sugiro um readme em inglês. 



