### PR TITLE
feat(deploy): add ci pipeline and drop obsolete compose version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy Bot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -e
+            cd ${{ secrets.BOT_DIR }}
+            git pull origin main
+            cd ${{ secrets.DASHBOARD_DIR }}/deploy
+            docker compose -f docker-compose.prod.yml up -d --build bot
+            docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   bot:
     container_name: bti_bot


### PR DESCRIPTION
The bot is deployed as a service of the unified compose in the dashboard repo, so its own compose stays for local dev only. Add github actions ssh deploy that pulls the bot repo and rebuilds the bot service.